### PR TITLE
hotfix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Instead of cloning the entire repository with its git history, you can create a 
 - **Using degit**: If you prefer not to include the original git history, you can use `degit`:
 
 ```bash
-pnpm dlx degit <your-repo-url> <your-project-name>
+pnpm dlx degit https://github.com/blazeshomida/nextjs14-starter-template <your-project-name>
 cd <your-project-name>
 pnpm install
 ```


### PR DESCRIPTION
fix: :wrench: add correct repository URL to README setup instructions
- :memo: Updated the 'Using degit' section to include the actual repository URL for clearer setup guidance.

This hotfix ensures users can accurately clone the project using the degit command, improving the setup experience.